### PR TITLE
Expand roles & personas for project management clarity and accountability

### DIFF
--- a/docs/docs/octoacme-roles-and-personas.md
+++ b/docs/docs/octoacme-roles-and-personas.md
@@ -1,0 +1,179 @@
+# OctoAcme Personas
+
+This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
+
+---
+
+## Developers
+
+### Role Summary
+Developers design, build, test, and deliver software components. They collaborate with product and project leads to implement features that meet acceptance criteria and quality standards.
+
+### Responsibilities
+- Implement features and fixes to meet acceptance criteria
+- Write and maintain tests and documentation
+- Participate in design and code reviews
+- Assist in estimating and planning work
+- Help identify technical risks and propose mitigations
+
+### Goals
+- Deliver reliable, maintainable code
+- Reduce cycle time from idea to production
+- Maintain high test coverage and observability
+
+### Typical Communication
+- Daily standups and sprint planning
+- PR descriptions and code review comments
+- Technical design docs when needed
+
+---
+
+## Product Managers
+
+### Role Summary
+Product Managers define what should be built to deliver customer and business value. They own the product vision, prioritize the backlog, and measure outcomes.
+
+### Responsibilities
+- Define problem statements and success metrics
+- Prioritize the roadmap and backlog
+- Collaborate with stakeholders and engineering on trade-offs
+- Validate solutions through user research and metrics
+
+### Goals
+- Maximize customer value and impact
+- Make clear, data-driven prioritization decisions
+- Ensure product-market fit and usability
+
+### Typical Communication
+- Weekly alignment with PM and engineering leads
+- Roadmap updates and stakeholder briefings
+- Acceptance criteria and feature specs
+
+---
+
+## Project Managers
+
+### Role Summary
+Project Managers coordinate delivery activities, manage schedules, risks, and communications. They enable the team to deliver on commitments efficiently.
+
+### Responsibilities
+- Create and maintain project plans and timelines
+- Manage risks, dependencies, and resource constraints
+- Facilitate meetings (kickoff, planning, retrospectives)
+- Ensure consistent project documentation and status reporting
+- Coordinate cross-team and stakeholder communication
+
+### Goals
+- Deliver projects on time and within scope
+- Minimize unplanned work and escalations
+- Maintain transparency and alignment across stakeholders
+
+### Typical Communication
+- Weekly status updates and stakeholder reports
+- Risk registers and decision logs
+- Coordination via project boards and meeting facilitation
+
+---
+
+## Scrum Master
+
+### Role Summary
+The Scrum Master is accountable for team-level process adoption, facilitating ceremonies, coaching the team, and removing delivery blockers.
+
+### Responsibilities
+- Facilitate agile ceremonies (standups, sprint planning, demos, retrospectives)
+- Support adoption of agreed processes and best practices
+- Identify and clear delivery impediments
+- Encourage psychological safety and continuous improvement
+
+### Goals
+- Foster a healthy, transparent, and productive team rhythm
+- Enable the team to deliver efficiently with minimal friction
+
+### Typical Communication
+- Works closely with PM, PdM, and Developers in ceremonies
+- Provides process coaching and feedback to the team
+
+### Role Interactions
+- Partners with PM to escalate blockers
+- Supports PdM and Developers in planning and demo prep
+
+---
+
+## UX Designer
+
+### Role Summary
+The UX Designer drives product usability, design quality, and user-centered thinking throughout the lifecycle.
+
+### Responsibilities
+- Define and evolve user flows, interactions, and visual design guidelines
+- Conduct user research and usability validation
+- Collaborate on acceptance criteria focused on user experience and accessibility
+- Provide design assets, specifications, and feedback to the team
+
+### Goals
+- Ensure features are valuable, intuitive, and accessible for users
+- Maintain high standards for usability in product releases
+
+### Typical Communication
+- Partners with Product Manager and Developers in feature design and reviews
+- Engages stakeholders and users for feedback cycles
+
+### Role Interactions
+- Works with PM/PdM to shape requirements for UX
+- Coordinates handoffs and clarifies intent with Developers
+
+---
+
+## Technical Writer
+
+### Role Summary
+The Technical Writer ensures essential process, product, and release documentation is accurate, clear, and accessible.
+
+### Responsibilities
+- Draft and maintain documentation: process guides, release notes, user guides, onboarding checklists
+- Collaborate with SMEs (subject matter experts) to clarify details
+- Support internal and external communication needs
+
+### Goals
+- Enable accessible, up-to-date project knowledge for onboarding and operations
+- Enhance transparency through well-maintained documentation
+
+### Typical Communication
+- Consults with the delivery team, PM, PdM, and other roles as needed
+- Publishes doc updates and release notes after major milestones
+
+### Role Interactions
+- Works closely with PM/PdM to ensure clarity of requirements and updates
+- Supports Developers and QA in documenting implementation and test details
+
+---
+
+## Release Manager
+
+### Role Summary
+The Release Manager coordinates deployment planning, technical readiness, and communications during releases.
+
+### Responsibilities
+- Oversee execution of the release plan, pre-release requirements, and post-release verification
+- Manage communication plans (stakeholders, support, incident response)
+- Ensure rollback and mitigation procedures are defined and practiced
+- Document and announce release notes and timelines
+
+### Goals
+- Minimize risk and downtime during releases
+- Ensure all release criteria and communications are met
+
+### Typical Communication
+- Interacts with Devs, QA, PM, PdM, and stakeholders pre- and post-release
+- Leads release-related meetings and comms
+
+### Role Interactions
+- Coordinates with PM for scheduling and incident playbooks
+- Partners with QA on release quality gates and readiness
+
+---
+
+## How these personas are used in the exercise
+- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
+- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.


### PR DESCRIPTION
This pull request updates docs/octoacme-roles-and-personas.md to add missing key roles to our project management documentation: Scrum Master, UX Designer, Technical Writer, and Release Manager. Each new persona includes a role summary, responsibilities, goals, communication pattern, and how they interact with existing roles—helping the team clarify ownership and accountability.

Closes #4 